### PR TITLE
Fix SVG badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ExTwitter [![Build Status](https://secure.travis-ci.org/parroty/extwitter.png?branch=master "Build Status")](http://travis-ci.org/parroty/extwitter) [![Coverage Status](https://coveralls.io/repos/parroty/extwitter/badge.png?branch=master)](http://img.shields.io/coveralls/parroty/extwitter.svg) [![Inline docs](http://inch-ci.org/github/parroty/extwitter.svg?branch=master&style=flat)](http://inch-ci.org/github/parroty/extwitter)
+# ExTwitter [![Build Status](https://img.shields.io/travis/parroty/extwitter.svg "Build Status")](http://travis-ci.org/parroty/extwitter) [![Coverage Status](http://img.shields.io/coveralls/parroty/extwitter.svg)](https://coveralls.io/r/parroty/extwitter) [![Inline docs](http://inch-ci.org/github/parroty/extwitter.svg?branch=master&style=flat)](http://inch-ci.org/github/parroty/extwitter)
 
 Twitter client library for elixir. It uses <a href="https://github.com/tim/erlang-oauth/" target="_blank">erlang-oauth</a> to call Twitter's REST API.
 


### PR DESCRIPTION
Looks like something got a little munged, this fixes the url and links for the inline badges so they link to the proper places and display in SVG for Retina/HiDPI displays.