### PR TITLE
CRLF parsing micro-optimization

### DIFF
--- a/lib/extwitter/api/streaming.ex
+++ b/lib/extwitter/api/streaming.ex
@@ -125,8 +125,9 @@ defmodule ExTwitter.API.Streaming do
     end
   end
 
-  defp is_empty_message(part), do: part == "\r\n"
-  defp is_end_of_message(part), do: part =~ ~r/\r\n$/
+  @crlf "\r\n"
+  def is_empty_message(part),  do: part == @crlf
+  def is_end_of_message(part), do: part |> String.ends_with?(@crlf)
 
   @doc false
   def parse_tweet_message(json, configs) do


### PR DESCRIPTION
This is a tiny optimization on how CRLFs are checked (`String.ends_with?` is faster than a regex), which speeds up the stream processing process by a few percentage points.

There are of course bigger fish to fry than this… E.g. it shouldn’t make a huge difference but I wanted to do a quick example of the sort of profiling/changes that should be possible since #11 to encourage people to look for optimization opportunities.

Before:
```
#process stream - single chunk:     100000   17.98 µs/op
#process stream - multi chunk:       50000   39.90 µs/op
```

After:
```
#process stream - single chunk:     100000   16.70 µs/op
#process stream - multi chunk:       50000   35.78 µs/op
```