### PR TITLE
Simplify travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,11 @@
-language: erlang
+language: elixir
+elixir:
+  - 1.0.0
+  - 1.0.2
 env:
-  - ELIXIR="v1.0.0"
-  - ELIXIR="v1.0.2"
+  - MIX_ENV=test
 otp_release:
   - 17.1
-before_install:
-  - mkdir -p vendor/elixir
-  - wget -q https://github.com/elixir-lang/elixir/releases/download/$ELIXIR/Precompiled.zip && unzip -qq Precompiled.zip -d vendor/elixir
-  - export PATH="$PATH:$PWD/vendor/elixir/bin"
-  - mix local.hex --force
-script: "MIX_ENV=test mix do deps.get, test && mix compile && mix coveralls.travis"
 after_script:
   - MIX_ENV=docs mix deps.get
   - MIX_ENV=docs mix do deps.get, inch.report


### PR DESCRIPTION
Simplify travis. Just a quick note on `sudo: false`. While it does use the `lxc` containers which is better, the infra at `travis-ci` is just not stable yet. If you have problems just switch back first. I had to do that for my own project.