### PR TITLE
[extwitter-18] Fixes #18 - follower_ids should support query by user_id

### DIFF
--- a/lib/extwitter/api/friends_and_followers.ex
+++ b/lib/extwitter/api/friends_and_followers.ex
@@ -21,8 +21,14 @@ defmodule ExTwitter.API.FriendsAndFollowers do
       |> ExTwitter.Parser.parse_ids_with_cursor
   end
 
-  def follower_ids(screen_name, options \\ []) do
-    follower_ids([screen_name: screen_name] ++ options)
+  def follower_ids(id, options \\ []) do
+    id_opt = cond do
+               is_number(id) ->
+                 [user_id: id]
+               true  ->
+                 [screen_name: id]
+             end
+    follower_ids(id_opt ++ options)
   end
 
   def friends(options) when is_list(options) do

--- a/test/extwitter_test.exs
+++ b/test/extwitter_test.exs
@@ -181,6 +181,13 @@ defmodule ExTwitterTest do
     end
   end
 
+  test "gets follower ids of twitter user by user_id" do
+    use_cassette "follower_ids" do
+      follower_ids_cursor = ExTwitter.follower_ids(783214, count: 1)
+      assert Enum.count(follower_ids_cursor.items) == 1
+    end
+  end
+
   test "gets friends of twitter user" do
     use_cassette "friends" do
       friends_cursor = ExTwitter.friends("twitter", count: 1)


### PR DESCRIPTION
ExTwitter.follower_ids/2 can now be called with either a screen name, or
a numeric user id, as the first argument. Either way the appropriate id
option will be made and prepended to the options (the second arg, or
default []).