### PR TITLE
fix config declaration in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The default behaviour is to configure using the application environment:
 In `config/config.exs`, add:
 
 ```elixir
-config :ex_twitter, :oauth, [
+config :extwitter, :oauth, [
    consumer_key: "",
    consumer_secret: "",
    access_token: "",


### PR DESCRIPTION
The existing documentation creates the following error:
```
You have configured application :ex_twitter in your config/config.exs
but the application is not available.

This usually means one of:

1. You have not added the application as a dependency in a mix.exs file.

2. You are configuring an application that does not really exist.

Please ensure :ex_twitter exists or remove the configuration.
```
This pr fixes the documentation to say 'extwitter' which doesn't error.