### PR TITLE
Tell Travis that sudo isn't needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,15 @@
 language: elixir
+
+sudo: false
+
 elixir:
   - 1.0.0
   - 1.1.1
+
 otp_release:
   - 17.4
   - 18.0
+
 script:
   - MIX_ENV=docs mix do deps.get, inch.report
   - MIX_ENV=test mix do deps.get, compile, coveralls.travis


### PR DESCRIPTION
This routes builds to the container based setup, which has a much faster boot time.