### PR TITLE
Add support to show a single direct message.

### DIFF
--- a/fixture/vcr_cassettes/list_direct_messages.json
+++ b/fixture/vcr_cassettes/list_direct_messages.json
@@ -1,0 +1,184 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": [],
+      "method": "get",
+      "options": {
+        "httpc_options": [],
+        "http_options": {
+          "autoredirect": "false"
+        }
+      },
+      "url": "https://api.twitter.com/1.1/direct_messages.json"
+    },
+    "response": {
+      "headers": {
+        "x-frame-options": "SAMEORIGIN",
+        "x-rate-limit-remaining": "13",
+        "last-modified": "Wed, 04 Nov 2015 10:35:52 GMT",
+        "status": "200 OK",
+        "content-length": "8242",
+        "x-response-time": "24",
+        "x-transaction": "6159f9084c2d8651",
+        "server": "tsa_b",
+        "pragma": "no-cache",
+        "cache-control": "no-cache, no-store, must-revalidate, pre-check=0, post-check=0",
+        "x-xss-protection": "1; mode=block",
+        "x-content-type-options": "nosniff",
+        "x-rate-limit-limit": 15,
+        "expires": "Tue, 31 Mar 1981 05:00:00 GMT",
+        "date": "Wed, 04 Nov 2015 10:35:52 GMT",
+        "content-type": "application/json; charset=utf-8",
+        "set-cookie":"<REMOVED> Domain=.twitter.com; Path=/; Expires=Fri, 03-Nov-2017 10:35:52 UTC",
+        "x-rate-limit-reset":"1446634233",
+        "x-access-level":"read-write-directmessages",
+        "x-twitter-response-tags": "BouncerCompliant",
+        "strict-transport-security": "max-age=631138519"
+      },
+      "status_code": [
+        "HTTP/1.1",
+        200,
+        "OK"
+      ],
+      "type": "ok",
+      "body": "[{
+  \"id\": 615025281712025600,
+  \"id_str\": \"615025281712025603\",
+  \"text\": \"In case there are any problems with locating the place\",
+  \"sender\": {
+    \"id\": 71686163,
+    \"id_str\": \"71686163\",
+    \"name\": \"cheenu madan\",
+    \"screen_name\": \"cmadan_\",
+    \"location\": \"New Delhi, India\",
+    \"description\": \"I just retweet as I go along.\",
+    \"url\": \"https://t.co/kdZSrk0V8B\",
+    \"entities\": {
+      \"url\": {
+        \"urls\": [
+          {
+            \"url\": \"https://t.co/kdZSrk0V8B\",
+            \"expanded_url\": \"https://www.wanto.in\",
+            \"display_url\": \"wanto.in\",
+            \"indices\": [
+              0,
+              23
+            ]
+          }
+        ]
+      },
+      \"description\": {
+        \"urls\": []
+      }
+    },
+    \"protected\": false,
+    \"followers_count\": 472,
+    \"friends_count\": 944,
+    \"listed_count\": 22,
+    \"created_at\": \"Sat Sep 05 00:54:34 +0000 2009\",
+    \"favourites_count\": 515,
+    \"utc_offset\": 19800,
+    \"time_zone\": \"New Delhi\",
+    \"geo_enabled\": true,
+    \"verified\": false,
+    \"statuses_count\": 6510,
+    \"lang\": \"en\",
+    \"contributors_enabled\": false,
+    \"is_translator\": false,
+    \"is_translation_enabled\": false,
+    \"profile_background_color\": \"131516\",
+    \"profile_background_image_url\": \"http://abs.twimg.com/images/themes/theme14/bg.gif\",
+    \"profile_background_image_url_https\": \"https://abs.twimg.com/images/themes/theme14/bg.gif\",
+    \"profile_background_tile\": true,
+    \"profile_image_url\": \"http://pbs.twimg.com/profile_images/452458321014833154/wRNlde77_normal.jpeg\",
+    \"profile_image_url_https\": \"https://pbs.twimg.com/profile_images/452458321014833154/wRNlde77_normal.jpeg\",
+    \"profile_link_color\": \"FF4422\",
+    \"profile_sidebar_border_color\": \"FFFFFF\",
+    \"profile_sidebar_fill_color\": \"EFEFEF\",
+    \"profile_text_color\": \"333333\",
+    \"profile_use_background_image\": true,
+    \"has_extended_profile\": false,
+    \"default_profile\": false,
+    \"default_profile_image\": false,
+    \"following\": true,
+    \"follow_request_sent\": false,
+    \"notifications\": false
+  },
+  \"sender_id\": 71686163,
+  \"sender_id_str\": \"71686163\",
+  \"sender_screen_name\": \"cmadan_\",
+  \"recipient\": {
+    \"id\": 14065315,
+    \"id_str\": \"14065315\",
+    \"name\": \"Waseem Ahmad\",
+    \"screen_name\": \"_waseem\",
+    \"location\": \"New Delhi, India\",
+    \"description\": \"I'm a Panzerfaust. I faust Panzers. And also a Duck Puncher. Archlinux user. Standup comedian in sleep. When does narwhal bacon?\",
+    \"url\": \"http://t.co/pJh7WcYv35\",
+    \"entities\": {
+      \"url\": {
+        \"urls\": [
+          {
+            \"url\": \"http://t.co/pJh7WcYv35\",
+            \"expanded_url\": \"http://waseem-ahmad.com\",
+            \"display_url\": \"waseem-ahmad.com\",
+            \"indices\": [
+              0,
+              22
+            ]
+          }
+        ]
+      },
+      \"description\": {
+        \"urls\": []
+      }
+    },
+    \"protected\": false,
+    \"followers_count\": 270,
+    \"friends_count\": 108,
+    \"listed_count\": 9,
+    \"created_at\": \"Sat Mar 01 16:12:49 +0000 2008\",
+    \"favourites_count\": 38,
+    \"utc_offset\": 19800,
+    \"time_zone\": \"New Delhi\",
+    \"geo_enabled\": true,
+    \"verified\": false,
+    \"statuses_count\": 4699,
+    \"lang\": \"en\",
+    \"contributors_enabled\": false,
+    \"is_translator\": false,
+    \"is_translation_enabled\": false,
+    \"profile_background_color\": \"0099B9\",
+    \"profile_background_image_url\": \"http://abs.twimg.com/images/themes/theme4/bg.gif\",
+    \"profile_background_image_url_https\": \"https://abs.twimg.com/images/themes/theme4/bg.gif\",
+    \"profile_background_tile\": false,
+    \"profile_image_url\": \"http://pbs.twimg.com/profile_images/630486679107665920/2RnJACza_normal.jpg\",
+    \"profile_image_url_https\": \"https://pbs.twimg.com/profile_images/630486679107665920/2RnJACza_normal.jpg\",
+    \"profile_banner_url\": \"https://pbs.twimg.com/profile_banners/14065315/1396063411\",
+    \"profile_link_color\": \"0099B9\",
+    \"profile_sidebar_border_color\": \"5ED4DC\",
+    \"profile_sidebar_fill_color\": \"95E8EC\",
+    \"profile_text_color\": \"3C3940\",
+    \"profile_use_background_image\": true,
+    \"has_extended_profile\": false,
+    \"default_profile\": false,
+    \"default_profile_image\": false,
+    \"following\": false,
+    \"follow_request_sent\": false,
+    \"notifications\": false
+  },
+  \"recipient_id\": 14065315,
+  \"recipient_id_str\": \"14065315\",
+  \"recipient_screen_name\": \"_waseem\",
+  \"created_at\": \"Sun Jun 28 05:13:48 +0000 2015\",
+  \"entities\": {
+    \"hashtags\": [],
+    \"symbols\": [],
+    \"user_mentions\": [],
+    \"urls\": []
+  }
+}]",
+    }
+  }
+]

--- a/fixture/vcr_cassettes/show_direct_message.json
+++ b/fixture/vcr_cassettes/show_direct_message.json
@@ -1,0 +1,183 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": [],
+      "method": "get",
+      "options": {
+        "httpc_options": [],
+        "http_options": {
+          "autoredirect": "false"
+        }
+      },
+      "url": "https://api.twitter.com/1.1/direct_messages/show/615025281712025603.json"
+    },
+    "response": {
+      "headers": {
+        "x-frame-options": "SAMEORIGIN",
+        "x-rate-limit-remaining": "14",
+        "last-modified": "Wed, 04 Nov 2015 08:57:55 GMT",
+        "status": "200 OK",
+        "content-length": "3610",
+        "x-response-time": "23",
+        "x-transaction": "2aeac564feba1057",
+        "server": "tsa_k",
+        "pragma": "no-cache",
+        "cache-control": "no-cache, no-store, must-revalidate, pre-check=0, post-check=0",
+        "x-xss-protection": "1; mode=block",
+        "x-content-type-options": "nosniff",
+        "x-rate-limit-limit": 15,
+        "expires": "Tue, 31 Mar 1981 05:00:00 GMT",
+        "date": "Wed, 04 Nov 2015 08:57:55 GMT",
+        "content-type": "application/json; charset=utf-8",
+        "set-cookie":"<REMOVED> Domain=.twitter.com; Path=/; Expires=Fri, 03-Nov-2017 08:57:55 UTC",
+        "x-rate-limit-reset":"1446628375",
+        "x-access-level":"read-write-directmessages",
+        "strict-transport-security": "max-age=631138519"
+      },
+      "status_code": [
+        "HTTP/1.1",
+        200,
+        "OK"
+      ],
+      "type": "ok",
+      "body": "{
+  \"id\": 615025281712025600,
+  \"id_str\": \"615025281712025603\",
+  \"text\": \"In case there are any problems with locating the place\",
+  \"sender\": {
+    \"id\": 71686163,
+    \"id_str\": \"71686163\",
+    \"name\": \"cheenu madan\",
+    \"screen_name\": \"cmadan_\",
+    \"location\": \"New Delhi, India\",
+    \"description\": \"I just retweet as I go along.\",
+    \"url\": \"https://t.co/kdZSrk0V8B\",
+    \"entities\": {
+      \"url\": {
+        \"urls\": [
+          {
+            \"url\": \"https://t.co/kdZSrk0V8B\",
+            \"expanded_url\": \"https://www.wanto.in\",
+            \"display_url\": \"wanto.in\",
+            \"indices\": [
+              0,
+              23
+            ]
+          }
+        ]
+      },
+      \"description\": {
+        \"urls\": []
+      }
+    },
+    \"protected\": false,
+    \"followers_count\": 472,
+    \"friends_count\": 944,
+    \"listed_count\": 22,
+    \"created_at\": \"Sat Sep 05 00:54:34 +0000 2009\",
+    \"favourites_count\": 515,
+    \"utc_offset\": 19800,
+    \"time_zone\": \"New Delhi\",
+    \"geo_enabled\": true,
+    \"verified\": false,
+    \"statuses_count\": 6510,
+    \"lang\": \"en\",
+    \"contributors_enabled\": false,
+    \"is_translator\": false,
+    \"is_translation_enabled\": false,
+    \"profile_background_color\": \"131516\",
+    \"profile_background_image_url\": \"http://abs.twimg.com/images/themes/theme14/bg.gif\",
+    \"profile_background_image_url_https\": \"https://abs.twimg.com/images/themes/theme14/bg.gif\",
+    \"profile_background_tile\": true,
+    \"profile_image_url\": \"http://pbs.twimg.com/profile_images/452458321014833154/wRNlde77_normal.jpeg\",
+    \"profile_image_url_https\": \"https://pbs.twimg.com/profile_images/452458321014833154/wRNlde77_normal.jpeg\",
+    \"profile_link_color\": \"FF4422\",
+    \"profile_sidebar_border_color\": \"FFFFFF\",
+    \"profile_sidebar_fill_color\": \"EFEFEF\",
+    \"profile_text_color\": \"333333\",
+    \"profile_use_background_image\": true,
+    \"has_extended_profile\": false,
+    \"default_profile\": false,
+    \"default_profile_image\": false,
+    \"following\": true,
+    \"follow_request_sent\": false,
+    \"notifications\": false
+  },
+  \"sender_id\": 71686163,
+  \"sender_id_str\": \"71686163\",
+  \"sender_screen_name\": \"cmadan_\",
+  \"recipient\": {
+    \"id\": 14065315,
+    \"id_str\": \"14065315\",
+    \"name\": \"Waseem Ahmad\",
+    \"screen_name\": \"_waseem\",
+    \"location\": \"New Delhi, India\",
+    \"description\": \"I'm a Panzerfaust. I faust Panzers. And also a Duck Puncher. Archlinux user. Standup comedian in sleep. When does narwhal bacon?\",
+    \"url\": \"http://t.co/pJh7WcYv35\",
+    \"entities\": {
+      \"url\": {
+        \"urls\": [
+          {
+            \"url\": \"http://t.co/pJh7WcYv35\",
+            \"expanded_url\": \"http://waseem-ahmad.com\",
+            \"display_url\": \"waseem-ahmad.com\",
+            \"indices\": [
+              0,
+              22
+            ]
+          }
+        ]
+      },
+      \"description\": {
+        \"urls\": []
+      }
+    },
+    \"protected\": false,
+    \"followers_count\": 270,
+    \"friends_count\": 108,
+    \"listed_count\": 9,
+    \"created_at\": \"Sat Mar 01 16:12:49 +0000 2008\",
+    \"favourites_count\": 38,
+    \"utc_offset\": 19800,
+    \"time_zone\": \"New Delhi\",
+    \"geo_enabled\": true,
+    \"verified\": false,
+    \"statuses_count\": 4699,
+    \"lang\": \"en\",
+    \"contributors_enabled\": false,
+    \"is_translator\": false,
+    \"is_translation_enabled\": false,
+    \"profile_background_color\": \"0099B9\",
+    \"profile_background_image_url\": \"http://abs.twimg.com/images/themes/theme4/bg.gif\",
+    \"profile_background_image_url_https\": \"https://abs.twimg.com/images/themes/theme4/bg.gif\",
+    \"profile_background_tile\": false,
+    \"profile_image_url\": \"http://pbs.twimg.com/profile_images/630486679107665920/2RnJACza_normal.jpg\",
+    \"profile_image_url_https\": \"https://pbs.twimg.com/profile_images/630486679107665920/2RnJACza_normal.jpg\",
+    \"profile_banner_url\": \"https://pbs.twimg.com/profile_banners/14065315/1396063411\",
+    \"profile_link_color\": \"0099B9\",
+    \"profile_sidebar_border_color\": \"5ED4DC\",
+    \"profile_sidebar_fill_color\": \"95E8EC\",
+    \"profile_text_color\": \"3C3940\",
+    \"profile_use_background_image\": true,
+    \"has_extended_profile\": false,
+    \"default_profile\": false,
+    \"default_profile_image\": false,
+    \"following\": false,
+    \"follow_request_sent\": false,
+    \"notifications\": false
+  },
+  \"recipient_id\": 14065315,
+  \"recipient_id_str\": \"14065315\",
+  \"recipient_screen_name\": \"_waseem\",
+  \"created_at\": \"Sun Jun 28 05:13:48 +0000 2015\",
+  \"entities\": {
+    \"hashtags\": [],
+    \"symbols\": [],
+    \"user_mentions\": [],
+    \"urls\": []
+  }
+}",
+    }
+  }
+]

--- a/lib/extwitter.ex
+++ b/lib/extwitter.ex
@@ -543,6 +543,28 @@ defmodule ExTwitter do
 
   # --------------  Direct Messages -------------
 
+  @doc """
+  GET direct_messages/show/:id
+
+  ## Examples
+
+      ExTwitter.direct_message(446328507694845952)
+
+  ## Reference
+  https://dev.twitter.com/rest/reference/get/direct_messages/show
+  """
+  @spec direct_message(Integer | String.t) :: ExTwitter.Model.DirectMessage.t
+  defdelegate direct_message(id), to: ExTwitter.API.DirectMessages
+
+  @doc """
+  GET direct_messages
+
+  ## Reference
+  https://dev.twitter.com/rest/reference/get/direct_messages
+  """
+  @spec direct_messages(Keyword.t) :: [ExTwitter.Model.DirectMessage.t]
+  defdelegate direct_messages(options), to: ExTwitter.API.DirectMessages
+
   # -------------- Friends & Followers -------------
 
   # GET friendships/no_retweets/ids

--- a/lib/extwitter/api/direct_messages.ex
+++ b/lib/extwitter/api/direct_messages.ex
@@ -1,0 +1,18 @@
+defmodule ExTwitter.API.DirectMessages do
+  @moduledoc """
+  Provides Direct Messages API interfaces.
+  """
+
+  import ExTwitter.API.Base
+
+  def direct_message(id) do
+    request(:get, "1.1/direct_messages/show/#{id}.json")
+    |> ExTwitter.Parser.parse_direct_message
+  end
+
+  def direct_messages(options \\ []) do
+    params = ExTwitter.Parser.parse_request_params(options)
+    request(:get, "1.1/direct_messages.json", params)
+    |> Enum.map(&ExTwitter.Parser.parse_direct_message/1)
+  end
+end

--- a/lib/extwitter/model.ex
+++ b/lib/extwitter/model.ex
@@ -54,6 +54,14 @@ defmodule ExTwitter.Model.User do
   @type t :: %__MODULE__{}
 end
 
+defmodule ExTwitter.Model.DirectMessage do
+  defstruct created_at: nil, entities: nil, id: nil, id_str: nil,
+    recipient: nil, recipient_id: nil, recipient_screen_name: nil,
+    sender: nil, sender_id: nil, sender_screen_name: nil, text: nil
+
+  @type t :: %__MODULE__{}
+end
+
 defmodule ExTwitter.Model.Entities do
   @moduledoc """
   Entities object.

--- a/lib/extwitter/parser.ex
+++ b/lib/extwitter/parser.ex
@@ -12,6 +12,15 @@ defmodule ExTwitter.Parser do
     %{tweet | user: user}
   end
 
+  @doc """
+  Parse direct message record from the API response
+  """
+  def parse_direct_message(object) do
+    direct_message = struct(ExTwitter.Model.DirectMessage, object)
+    recipient      = parse_user(direct_message.recipient)
+    sender         = parse_user(direct_message.sender)
+    %{direct_message | recipient: recipient, sender: sender}
+  end
 
   def parse_upload(object) do
     struct(ExTwitter.Model.Upload, object)

--- a/test/extwitter_test.exs
+++ b/test/extwitter_test.exs
@@ -98,6 +98,21 @@ defmodule ExTwitterTest do
     end
   end
 
+  test "shows direct message" do
+    use_cassette "show_direct_message" do
+      direct_message = ExTwitter.direct_message(615025281712025603)
+      assert direct_message.text =~ ~r/In case there are any problems with locating the place/
+    end
+  end
+
+  test "gets direct messages list" do
+    use_cassette "list_direct_messages" do
+      direct_messages = ExTwitter.direct_messages(count: 1)
+      assert Enum.count(direct_messages) == 1
+      assert List.first(direct_messages).text =~ ~r/In case there are any problems with locating the place/
+    end
+  end
+
   test "update and destroy status" do
     use_cassette "update_destroy_status" do
       tweet1 = ExTwitter.update("update sample")


### PR DESCRIPTION
I was not able to test this though. When I run tests, I get following error.

```
 1) test shows direct message (ExTwitterTest)
     test/extwitter_test.exs:101
     ** (ExVCR.RequestNotMatchError) Request did not match with any one in the current cassette: fixture/vcr_cassettes/show_direct_message.json.
     Delete the current cassette with [mix vcr.delete] and re-record.
     
     stacktrace:
       lib/exvcr/handler.ex:116: ExVCR.Handler.raise_error_if_cassette_already_exists/1
       lib/exvcr/handler.ex:100: ExVCR.Handler.get_response_from_server/2
       (inets) :httpc.request(:get, {'https://api.twitter.com/1.1/direct_messages/show/446328507694845952.json?oauth_signature=ZyUwlXCAMj8CXyr2V6kSfHcEOjo%3D&oauth_version=1.0&oauth_nonce=fVfwbwczFr6Lf6h7K9MppaoK%2FpdE7NvZqUUyYjQTM%2Bg%3D&oauth_timestamp=1446520933&oauth_signature_method=HMAC-SHA1&oauth_consumer_key=nil&oauth_token=nil', []}, [autoredirect: false], [])
       (extwitter) lib/extwitter/api/base.ex:26: ExTwitter.API.Base.do_request/3
       (extwitter) lib/extwitter/api/direct_messages.ex:10: ExTwitter.API.DirectMessages.direct_message/2
       test/extwitter_test.exs:103
```

I do not know id of a direct message that I could use in tests. How will I go with testing it?

cc: @parroty 