### PR TITLE
Fix auth methods so that redirect_url makes sense

### DIFF
--- a/lib/extwitter.ex
+++ b/lib/extwitter.ex
@@ -1429,6 +1429,20 @@ defmodule ExTwitter do
 
   ## Examples
 
+      ExTwitter.request_token("http://myapp.com/twitter-callback")
+
+  ## Reference
+  https://dev.twitter.com/oauth/reference/post/oauth/request_token
+  https://dev.twitter.com/web/sign-in/implementing
+  """
+  @spec request_token(String.t) :: [ExTwitter.Model.RequestToken.t]
+  defdelegate request_token(redirect_url), to: ExTwitter.API.Auth
+
+  @doc """
+  POST oauth/request_token
+
+  ## Examples
+
       ExTwitter.request_token
 
   ## Reference
@@ -1445,33 +1459,15 @@ defmodule ExTwitter do
   ## Examples
 
       token = ExTwitter.request_token
-      ExTwitter.authorize_url(
-          token.oauth_token, "http://myapp.com/twitter-callback", %{force_login: true})
+      ExTwitter.authorize_url(token.oauth_token, %{force_login: true})
 
   ## Reference
   https://dev.twitter.com/oauth/reference/get/oauth/authorize
   https://dev.twitter.com/oauth/3-legged
   https://dev.twitter.com/web/sign-in/implementing
   """
-  @spec authorize_url(String.t, String.t, Map.t) :: {:ok, String.t} | {:error, String.t}
-  defdelegate authorize_url(oauth_token, redirect_url, options), to: ExTwitter.API.Auth
-
-  @doc """
-  GET oauth/authorize
-  Returns the URL you should redirect the user to for 3-legged authorization
-
-  ## Examples
-
-      token = ExTwitter.request_token
-      ExTwitter.authorize_url(token.oauth_token, "http://myapp.com/twitter-callback")
-
-  ## Reference
-  https://dev.twitter.com/oauth/reference/get/oauth/authorize
-  https://dev.twitter.com/oauth/3-legged
-  https://dev.twitter.com/web/sign-in/implementing
-  """
-  @spec authorize_url(String.t, String.t) :: {:ok, String.t} | {:error, String.t}
-  defdelegate authorize_url(oauth_token, redirect_url), to: ExTwitter.API.Auth
+  @spec authorize_url(String.t, Map.t) :: {:ok, String.t} | {:error, String.t}
+  defdelegate authorize_url(oauth_token, options), to: ExTwitter.API.Auth
 
   @doc """
   GET oauth/authorize
@@ -1493,31 +1489,14 @@ defmodule ExTwitter do
   ## Examples
 
       token = ExTwitter.request_token
-      ExTwitter.authenticate_url(
-          token.oauth_token, "http://myapp.com/twitter-callback", %{force_login: true})
+      ExTwitter.authenticate_url(token.oauth_token, %{force_login: true})
 
   ## Reference
   https://dev.twitter.com/oauth/reference/get/oauth/authenticate
   https://dev.twitter.com/web/sign-in/implementing
   """
-  @spec authenticate_url(String.t, String.t, Map.t) :: {:ok, String.t} | {:error, String.t}
-  defdelegate authenticate_url(oauth_token, redirect_url, options), to: ExTwitter.API.Auth
-
-  @doc """
-  GET oauth/authenticate
-  Returns the URL you should redirect the user to for twitter sign-in
-
-  ## Examples
-
-      token = ExTwitter.request_token
-      ExTwitter.authenticate_url(token.oauth_token, "http://myapp.com/twitter-callback")
-
-  ## Reference
-  https://dev.twitter.com/oauth/reference/get/oauth/authenticate
-  https://dev.twitter.com/web/sign-in/implementing
-  """
-  @spec authenticate_url(String.t, String.t) :: {:ok, String.t} | {:error, String.t}
-  defdelegate authenticate_url(oauth_token, redirect_url), to: ExTwitter.API.Auth
+  @spec authenticate_url(String.t Map.t) :: {:ok, String.t} | {:error, String.t}
+  defdelegate authenticate_url(oauth_token, options), to: ExTwitter.API.Auth
 
   @doc """
   GET oauth/authenticate

--- a/lib/extwitter/api/auth.ex
+++ b/lib/extwitter/api/auth.ex
@@ -4,11 +4,12 @@ defmodule ExTwitter.API.Auth do
   """
   import ExTwitter.API.Base
 
-  def request_token() do
+  def request_token(redirect_url \\ nil) do
     oauth = ExTwitter.Config.get_tuples |> verify_params
+    params = if redirect_url, do: [{"oauth_callback", redirect_url}], else: []
     consumer = {oauth[:consumer_key], oauth[:consumer_secret], :hmac_sha1}
     {:ok, {{_, 200, _}, _headers, body}} =
-      ExTwitter.OAuth.request(:post, request_url("oauth/request_token"), [], consumer, [], [])
+      ExTwitter.OAuth.request(:post, request_url("oauth/request_token"), params, consumer, [], [])
 
     Elixir.URI.decode_query(to_string body)
     |> Enum.map(fn {k,v} -> {String.to_atom(k), v} end)
@@ -16,22 +17,14 @@ defmodule ExTwitter.API.Auth do
     |> ExTwitter.Parser.parse_request_token
   end
 
-  def authorize_url(oauth_token, redirect_url \\ nil, options \\ %{}) do
+  def authorize_url(oauth_token, options \\ %{}) do
     args = Map.merge(%{oauth_token: oauth_token}, options)
-
-    if redirect_url do
-      args = Map.merge(%{oauth_callback: redirect_url}, args)
-    end
 
     {:ok, request_url("oauth/authorize?" <> Elixir.URI.encode_query(args)) |> to_string}
   end
 
-  def authenticate_url(oauth_token, redirect_url \\ nil, options \\ %{}) do
+  def authenticate_url(oauth_token, options \\ %{}) do
     args = Map.merge(%{oauth_token: oauth_token}, options)
-
-    if redirect_url do
-      args = Map.merge(%{oauth_callback: redirect_url}, args)
-    end
 
     {:ok, request_url("oauth/authenticate?" <> Elixir.URI.encode_query(args)) |> to_string}
   end

--- a/test/extwitter_test.exs
+++ b/test/extwitter_test.exs
@@ -424,17 +424,10 @@ defmodule ExTwitterTest do
     # Check generated oauth authorize url against twitter url pattern
     # Validating the URL actually works is essentially a manual test
     token = "some_token"
-    url = "http://some_domain.com/some_url"
-
-    params = %{oauth_token: token, oauth_callback: url} |> URI.encode_query
-
-    {:ok, regex_callback} = Regex.compile("^https://api.twitter.com/oauth/authorize\\?" <> params)
     {:ok, regex} = Regex.compile("^https://api.twitter.com/oauth/authorize\\?oauth_token=" <> token)
 
-    {:ok, authorize_url_with_callback} = ExTwitter.authorize_url(token, url)
     {:ok, authorize_url} = ExTwitter.authorize_url(token)
 
-    assert Regex.match?(regex_callback, authorize_url_with_callback)
     assert Regex.match?(regex, authorize_url)
   end
 
@@ -442,17 +435,10 @@ defmodule ExTwitterTest do
     # Check generated oauth authenticate url against twitter url pattern
     # Validating the URL actually works is essentially a manual test
     token = "some_token"
-    url = "http://some_domain.com/some_url"
-
-    params = %{oauth_token: token, oauth_callback: url} |> URI.encode_query
-
-    {:ok, regex_callback} = Regex.compile("^https://api.twitter.com/oauth/authenticate\\?" <> params)
     {:ok, regex} = Regex.compile("^https://api.twitter.com/oauth/authenticate\\?oauth_token=" <> token)
 
-    {:ok, authenticate_url_with_callback} = ExTwitter.authenticate_url(token, url)
     {:ok, authenticate_url} = ExTwitter.authenticate_url(token)
 
-    assert Regex.match?(regex_callback, authenticate_url_with_callback)
     assert Regex.match?(regex, authenticate_url)
   end
 


### PR DESCRIPTION
The oauth_callback parameter should be POSTed to `/oauth/request_token` according to https://dev.twitter.com/web/sign-in/implementing .

This commit

- adds `ExTwitter.request_token(redirect_url)`
- removes `redirect_url` parameter from `ExTwitter.authorize_url`
- removes `redirect_url` parameter from `ExTwitter.authenticate_url`