### PR TITLE
Add extended_entities field to Model.Tweet

### DIFF
--- a/lib/extwitter/model.ex
+++ b/lib/extwitter/model.ex
@@ -6,7 +6,7 @@ defmodule ExTwitter.Model.Tweet do
   https://dev.twitter.com/overview/api/tweets
   """
   defstruct contributors: nil, coordinates: nil, created_at: nil,
-    current_user_retweet: nil, entities: nil, favorite_count: nil,
+    current_user_retweet: nil, entities: nil, extended_entities: nil, favorite_count: nil,
     favorited: nil, filter_level: nil, geo: nil, id: nil, id_str: nil,
     in_reply_to_screen_name: nil, in_reply_to_status_id: nil,
     in_reply_to_status_id_str: nil, in_reply_to_user_id: nil,


### PR DESCRIPTION
The `extended_entities` field is not listed here https://dev.twitter.com/overview/api/tweets but does exist. See also https://dev.twitter.com/overview/api/entities-in-twitter-objects#extended_entities