### PR TITLE
Add method to support requests to Ads API.

### DIFF
--- a/lib/extwitter/api/base.ex
+++ b/lib/extwitter/api/base.ex
@@ -20,6 +20,13 @@ defmodule ExTwitter.API.Base do
     do_request(method, upload_url(path), params)
   end
 
+  @doc """
+  Send request to the ads-api.twitter.com server.
+  """
+  def ads_request(method, path, params \\ []) do
+    do_request(method, ads_url(path), params)
+  end
+
   defp do_request(method, url, params) do
     oauth = ExTwitter.Config.get_tuples |> verify_params
     consumer = {oauth[:consumer_key], oauth[:consumer_secret], :hmac_sha1}
@@ -49,6 +56,10 @@ defmodule ExTwitter.API.Base do
 
   defp upload_url(path) do
     "https://upload.twitter.com/#{path}" |> to_char_list
+  end
+
+  defp ads_url(path) do
+    "https://ads-api.twitter.com/#{path}" |> to_char_list
   end
 
   def parse_result(result) do


### PR DESCRIPTION
At this time, supports bare requests going to the new URL.

I don't anticipate that there will be a need to add methods to emulate all of the Ads API functionality - using this request method directly should be enough. (And since their ads API is still at version "0", it's subject to changes anyway.)