### PR TITLE
Upgrade timex to 1.0.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -35,7 +35,7 @@ defmodule ExTwitter.Mixfile do
     [
       {:oauth, github: "tim/erlang-oauth"},
       {:poison, "~> 1.5"},
-      {:timex, "~> 0.19"},
+      {:timex, "~> 1.0.0"},
       {:exvcr, "~> 0.6", only: :test},
       {:excoveralls, "~> 0.4", only: :test},
       {:meck, "~> 0.8.2", only: [:dev, :test]},

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{"benchfella": {:git, "https://github.com/alco/benchfella.git", "9513b94538fd3df28d12e3b999d397658146c005", []},
   "certifi": {:hex, :certifi, "0.3.0"},
-  "combine": {:hex, :combine, "0.5.2"},
+  "combine": {:hex, :combine, "0.7.0"},
   "earmark": {:hex, :earmark, "0.1.19"},
   "ex_doc": {:hex, :ex_doc, "0.11.2"},
   "exactor": {:hex, :exactor, "2.2.0"},
@@ -21,5 +21,5 @@
   "oauth": {:git, "https://github.com/tim/erlang-oauth.git", "2ee206ea921722893200a0ad534c6b6130233325", []},
   "poison": {:hex, :poison, "1.5.0"},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"},
-  "timex": {:hex, :timex, "0.19.2"},
-  "tzdata": {:hex, :tzdata, "0.1.7"}}
+  "timex": {:hex, :timex, "1.0.0"},
+  "tzdata": {:hex, :tzdata, "0.5.6"}}


### PR DESCRIPTION
This fixes annoying warnings when building under Elixir 1.2.x.

I had to unlock `combine` and `tzdata` as well to satisfy dependency
constraints.

Travis CI says nothing breaks : https://travis-ci.org/jonathanperret/extwitter/builds/105125735