### PR TITLE
Expose user_id and screen_name from access_token response

### DIFF
--- a/lib/extwitter/model.ex
+++ b/lib/extwitter/model.ex
@@ -140,7 +140,7 @@ defmodule ExTwitter.Model.RequestToken do
 end
 
 defmodule ExTwitter.Model.AccessToken do
-  defstruct oauth_token: nil, oauth_token_secret: nil
+  defstruct oauth_token: nil, oauth_token_secret: nil, user_id: nil, screen_name: nil
 
   @type t :: %__MODULE__{}
 end

--- a/test/extwitter_test.exs
+++ b/test/extwitter_test.exs
@@ -451,7 +451,9 @@ defmodule ExTwitterTest do
 
       assert access_token != nil
       assert access_token.oauth_token != nil
-      assert access_token.oauth_token_secret != nil
+      assert access_token.oauth_token != nil
+      assert access_token.user_id == "28487251"
+      assert access_token.screen_name == "julianobs"
     end
   end
 end


### PR DESCRIPTION
Twitter provides the `user_id` and `screen_name` for the authenticating user in the `oauth/access_token` response. This change makes these values accessible on the AccessToken struct, saving a `/verify_credentials` call to know who just authenticated.