### PR TITLE
Trap connection errors and raise with custom exception

### DIFF
--- a/fixture/custom_cassettes/failed_connection.json
+++ b/fixture/custom_cassettes/failed_connection.json
@@ -1,0 +1,20 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": [],
+      "method": "get",
+      "options": {
+        "httpc_options": [],
+        "http_options": []
+      },
+      "url": "~r/https://api.twitter.com/1.1/followers/ids.json\\?.+/"
+    },
+    "response": {
+      "body": "failed_connect",
+      "headers": [],
+      "status_code": null,
+      "type": "error"
+    }
+  }
+]

--- a/lib/extwitter/api/base.ex
+++ b/lib/extwitter/api/base.ex
@@ -23,8 +23,12 @@ defmodule ExTwitter.API.Base do
   defp do_request(method, url, params) do
     oauth = ExTwitter.Config.get_tuples |> verify_params
     consumer = {oauth[:consumer_key], oauth[:consumer_secret], :hmac_sha1}
-    ExTwitter.OAuth.request(method, url, params, consumer, oauth[:access_token], oauth[:access_token_secret])
-    |> parse_result
+    token = oauth[:access_token]
+    secret = oauth[:access_token_secret]
+    case ExTwitter.OAuth.request(method, url, params, consumer, token, secret) do
+      {:error, reason} -> raise(ExTwitter.ConnectionError, reason: reason)
+      r -> r |> parse_result
+    end
   end
 
   def verify_params([]) do

--- a/lib/extwitter/exception.ex
+++ b/lib/extwitter/exception.ex
@@ -5,3 +5,7 @@ end
 defmodule ExTwitter.RateLimitExceededError do
   defexception [:code, :message, :reset_in, :reset_at]
 end
+
+defmodule ExTwitter.ConnectionError do
+  defexception [:reason, message: "connection error"]
+end

--- a/test/extwitter_test.exs
+++ b/test/extwitter_test.exs
@@ -472,4 +472,12 @@ defmodule ExTwitterTest do
       assert access_token.screen_name == "julianobs"
     end
   end
+
+  test "failed connection" do
+    use_cassette "failed_connection", custom: true do
+      assert_raise ExTwitter.ConnectionError, "connection error", fn ->
+        ExTwitter.follower_ids("twitter", count: 1)
+      end
+    end
+  end
 end


### PR DESCRIPTION
I've added a custom `ConnectionError` exception, to trap situations where the connection to Twitter fails. This is an improvement over what currently happens, which is a `MatchError` exception.