### PR TITLE
Don’t throw errors for “normal” errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+0.8.0
+------
+
+* API Change - Major changes related to ExTwitter raising errors.
+    - Most calls will now return an {:error, message} tuple
+      instead of raising an error directly
+
 0.7.2
 ------
 #### Changes

--- a/lib/extwitter/api/base.ex
+++ b/lib/extwitter/api/base.ex
@@ -26,7 +26,7 @@ defmodule ExTwitter.API.Base do
     token = oauth[:access_token]
     secret = oauth[:access_token_secret]
     case ExTwitter.OAuth.request(method, url, params, consumer, token, secret) do
-      {:error, reason} -> raise(ExTwitter.ConnectionError, reason: reason)
+      {:error, {reason, _}} -> {:error, "ConnectionError: #{reason}"}
       r -> r |> parse_result
     end
   end
@@ -70,7 +70,7 @@ defmodule ExTwitter.API.Base do
         errors when is_list(errors) ->
           parse_error(List.first(errors), header)
         error ->
-          raise(ExTwitter.Error, message: inspect error)
+          {:error, "Error: #{inspect error}"}
       end
     end
   end
@@ -81,10 +81,8 @@ defmodule ExTwitter.API.Base do
       @error_code_rate_limit_exceeded ->
         reset_at = fetch_rate_limit_reset(header)
         reset_in = Enum.max([reset_at - now, 0])
-        raise ExTwitter.RateLimitExceededError,
-          code: code, message: message, reset_at: reset_at, reset_in: reset_in
-      _  ->
-        raise ExTwitter.Error, code: code, message: message
+        {:error, "RateLimitExceeded: #{message}, reset at: #{reset_at}, reset in: #{reset_in}"}
+      _  -> {:error, "Error: #{message}"}
     end
   end
 

--- a/lib/extwitter/api/search.ex
+++ b/lib/extwitter/api/search.ex
@@ -7,7 +7,12 @@ defmodule ExTwitter.API.Search do
 
   def search(query, options \\ []) do
     params = ExTwitter.Parser.parse_request_params([q: query] ++ options)
-    json = request(:get, "1.1/search/tweets.json", params)
-    ExTwitter.JSON.get(json, :statuses) |> Enum.map(&ExTwitter.Parser.parse_tweet/1)
+    case request(:get, "1.1/search/tweets.json", params) do
+      {:error, msg} -> {:error, msg}
+      json ->
+        json
+        |> ExTwitter.JSON.get(:statuses)
+        |> Enum.map(&ExTwitter.Parser.parse_tweet/1)
+    end
   end
 end

--- a/lib/extwitter/parser.ex
+++ b/lib/extwitter/parser.ex
@@ -61,6 +61,7 @@ defmodule ExTwitter.Parser do
   @doc """
   Parse cursored ids.
   """
+  def parse_ids_with_cursor({:error, msg}), do: {:error, msg}
   def parse_ids_with_cursor(object) do
     ids = object |> ExTwitter.JSON.get(:ids)
     cursor = struct(ExTwitter.Model.Cursor, object)
@@ -70,6 +71,7 @@ defmodule ExTwitter.Parser do
   @doc """
   Parse cursored users.
   """
+  def parse_users_with_cursor({:error, msg}), do: {:error, msg}
   def parse_users_with_cursor(object) do
     users = object |> ExTwitter.JSON.get(:users)
                    |> Enum.map(&ExTwitter.Parser.parse_user/1)

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule ExTwitter.Mixfile do
 
   def project do
     [ app: :extwitter,
-      version: "0.7.2",
+      version: "0.8.0",
       elixir: ">= 1.0.0",
       deps: deps,
       description: description,

--- a/test/extwitter_test.exs
+++ b/test/extwitter_test.exs
@@ -78,9 +78,8 @@ defmodule ExTwitterTest do
 
   test "search with invalid count param raises error" do
     use_cassette "search_invalid_count" do
-      assert_raise ExTwitter.Error, fn ->
-        ExTwitter.search("test", count: -1)
-      end
+      {:error, message} = ExTwitter.search("test", count: -1)
+      assert Regex.match?(~r/^Error: count parameter is invalid/, message)
     end
   end
 
@@ -419,9 +418,10 @@ defmodule ExTwitterTest do
 
   test "rate limit exceed" do
     use_cassette "rate_limit_exceed", custom: true do
-      assert_raise ExTwitter.RateLimitExceededError, fn ->
-        ExTwitter.follower_ids("twitter", count: 1)
-      end
+      {:error, msg} = ExTwitter.follower_ids("twitter", count: 1)
+      assert Regex.match?(~r/^RateLimitExceeded/, msg)
+      assert Regex.match?(~r/reset at: \d+/, msg)
+      assert Regex.match?(~r/reset in: \d+/, msg)
     end
   end
 
@@ -475,9 +475,8 @@ defmodule ExTwitterTest do
 
   test "failed connection" do
     use_cassette "failed_connection", custom: true do
-      assert_raise ExTwitter.ConnectionError, "connection error", fn ->
-        ExTwitter.follower_ids("twitter", count: 1)
-      end
+      {:error, reason} = ExTwitter.follower_ids("twitter", count: 1)
+      assert Regex.match?(~r/^ConnectionError:/, reason)
     end
   end
 end


### PR DESCRIPTION
Return the more-standard elixir tuple of
{:error, message} and let the user decide what
they want to do with it. 

We still raise hard errors for truly unrecoverable
things like missing keys and/or configuration
options.

[Fix #52]
