### PR TITLE
Fix document and spec

### DIFF
--- a/lib/extwitter.ex
+++ b/lib/extwitter.ex
@@ -515,12 +515,12 @@ defmodule ExTwitter do
 
   ## Examples
 
-      ExTwitter.stream_filter(track: "apple", timeout: 60000)
+      ExTwitter.stream_filter(track: "apple", 60000)
 
   ## Reference
   https://dev.twitter.com/streaming/reference/post/statuses/filter
   """
-  @spec stream_filter(Keyword.t, [timeout: Integer]) :: Enumerable.t
+  @spec stream_filter(Keyword.t, timeout) :: Enumerable.t
   defdelegate stream_filter(options, timeout), to: ExTwitter.API.Streaming
 
   @doc """


### PR DESCRIPTION
The code of `ExTwitter.API.Streaming.stream_filter/2` take timeout value as the second argument.
It must not be a Keyword(e.g `[timeout: 60_000]`).
Instead, It must be a non negative number or `:infinity`.

I thought `timeout` value is passed following codes:

https://github.com/parroty/extwitter/blob/master/lib/extwitter/api/streaming.ex#L25
https://github.com/parroty/extwitter/blob/master/lib/extwitter/api/streaming.ex#L29
https://github.com/parroty/extwitter/blob/master/lib/extwitter/api/streaming.ex#L77
https://github.com/parroty/extwitter/blob/master/lib/extwitter/api/streaming.ex#L80
https://github.com/parroty/extwitter/blob/master/lib/extwitter/api/streaming.ex#L89
https://github.com/parroty/extwitter/blob/master/lib/extwitter/api/streaming.ex#L90
https://github.com/parroty/extwitter/blob/master/lib/extwitter/api/streaming.ex#L93
https://github.com/parroty/extwitter/blob/master/lib/extwitter/api/streaming.ex#L94