### PR TITLE
Explicitly specify required libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ ExTwitter.configure(:process, [consumer_key: "", ...])
 ```elixir
 defp deps do
   [
+    {:oauther, "~> 1.1"},
     {:extwitter, "~> 0.8"}
   ]
 end


### PR DESCRIPTION
Avoid missing dependency error on production environments. t.ex: module OAuther is not available