### PR TITLE
Bugfix/cleanup char list deprecation warnings

### DIFF
--- a/lib/extwitter/oauth.ex
+++ b/lib/extwitter/oauth.ex
@@ -35,7 +35,7 @@ defmodule ExTwitter.OAuth do
     signed_params = get_signed_params(
       "get", url, params, consumer_key, consumer_secret, access_token, access_token_secret)
     encoded_params = URI.encode_query(signed_params)
-    request = {to_char_list(url <> "?" <> encoded_params), []}
+    request = {to_charlist(url <> "?" <> encoded_params), []}
     send_httpc_request(:get, request, options)
   end
 
@@ -43,7 +43,7 @@ defmodule ExTwitter.OAuth do
     signed_params = get_signed_params(
       "post", url, params, consumer_key, consumer_secret, access_token, access_token_secret)
     encoded_params = URI.encode_query(signed_params)
-    request = {to_char_list(url), [], 'application/x-www-form-urlencoded', encoded_params}
+    request = {to_charlist(url), [], 'application/x-www-form-urlencoded', encoded_params}
     send_httpc_request(:post, request, options)
   end
 

--- a/lib/extwitter/proxy.ex
+++ b/lib/extwitter/proxy.ex
@@ -25,7 +25,7 @@ defmodule ExTwitter.Proxy do
 
   def get_proxy_option(proxy) do
     if proxy[:server] != nil && proxy[:port] != nil do
-      server = String.to_char_list(proxy[:server])
+      server = String.to_charlist(proxy[:server])
       port = parse_port(proxy[:port])
       [{:proxy, {{server, port}, []}}]
     else
@@ -35,8 +35,8 @@ defmodule ExTwitter.Proxy do
 
   def get_auth_option(proxy) do
     if proxy[:user] != nil && proxy[:password] != nil do
-      user = String.to_char_list(proxy[:user])
-      password = String.to_char_list(proxy[:password])
+      user = String.to_charlist(proxy[:user])
+      password = String.to_charlist(proxy[:password])
       [{:proxy_auth, {user, password}}]
     else
       []


### PR DESCRIPTION
I changed the name of the deprecated .to_char_list functions to the actual .to_charlist functions. (!) This may be a breaking change for older versions of elixir.