### PR TITLE
Fixed crash if message is not string actually

### DIFF
--- a/lib/extwitter/api/streaming.ex
+++ b/lib/extwitter/api/streaming.ex
@@ -110,7 +110,7 @@ defmodule ExTwitter.API.Streaming do
         receive_next_tweet(nil, req, timeout)
 
       {:error, message} ->
-        Logger.error "Error returned, stopping stream (#{message})."
+        Logger.error "Error returned, stopping stream (#{inspect(message)})."
         {:halt, {req, pid}}
 
       _ ->


### PR DESCRIPTION
E.g. in case if `message` is error from `Poison`

```elixir
{{:invalid, "s", 0}, "ss"}
```

сс @parroty 