### PR TITLE
Add `full_text` field back into tweet model

### DIFF
--- a/lib/extwitter/model.ex
+++ b/lib/extwitter/model.ex
@@ -14,7 +14,7 @@ defmodule ExTwitter.Model.Tweet do
     place: nil, possibly_sensitive: nil, quote_count: nil, quoted_status_id_str: nil,
     quoted_status_id: nil, quoted_status: nil, raw_data: nil, reply_count: nil,
     retweet_count: nil, retweeted_status: nil, retweeted: nil, scopes: nil, source: nil,
-    text: nil, truncated: nil, user: nil, withheld_copyright: nil,
+    text: nil, full_text: nil, truncated: nil, user: nil, withheld_copyright: nil,
     withheld_in_countries: nil, withheld_scope: nil
 
   @type t :: %__MODULE__{
@@ -50,6 +50,7 @@ defmodule ExTwitter.Model.Tweet do
     scopes: map | nil,
     source: String.t(),
     text: String.t(),
+    full_text: String.t(),
     truncated: boolean,
     user: ExTwitter.Model.User.t(),
     withheld_copyright: boolean | nil,


### PR DESCRIPTION
If you use `extended_mode` for getting tweets the tweet does not have a `text` field, instead it contains a `full_text` field.

ex:
 
```elixir
ExTwitter.search("search-term", count: 20, tweet_mode: "extended")
```

Reference:

https://developer.twitter.com/en/docs/tweets/tweet-updates