### PR TITLE
Make Jason library an optional dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,7 @@ defmodule ExTwitter.Mixfile do
   def deps do
     [
       {:oauther, "~> 1.1"},
-      {:jason, "~> 1.1"},
+      {:jason, "~> 1.1", optional: true},
       {:exvcr, "~> 0.8", only: :test},
       {:excoveralls, "~> 0.7", only: :test},
       {:meck, "~> 0.8.13", only: [:dev, :test]},


### PR DESCRIPTION
Since the user can select their own json library we should make the Jason dependency optional.

If not Jason will always be pulled in even if the user uses a different dependency for json encoding/decoding.