### PR TITLE
Remove unneeded mix application instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,6 @@ defp deps do
     {:extwitter, "~> 0.8"}
   ]
 end
-
-...
-
-def application do
-  [applications: [:logger, :extwitter]]
-end
 ```
 
 #### JSON support


### PR DESCRIPTION
Since Elixir 1.4, it was no longer necessary to add dependencies to the
mix `:applications` list. Elixir figures this out automatically. This
change removes that part from the instructions.