### PR TITLE
Fix derive missing field issue

### DIFF
--- a/lib/extwitter/model.ex
+++ b/lib/extwitter/model.ex
@@ -176,7 +176,7 @@ defmodule ExTwitter.Model.ProfileBanner do
 end
 
 defmodule ExTwitter.Model.DirectMessage do
-  @derive {Inspect, except: [:raw_data]}
+  @derive Inspect
   defstruct created_at: nil,
             entities: nil,
             id: nil,

--- a/lib/extwitter/model.ex
+++ b/lib/extwitter/model.ex
@@ -7,71 +7,98 @@ defmodule ExTwitter.Model.Tweet do
   [Tweet object](https://developer.twitter.com/en/docs/tweets/data-dictionary/overview/tweet-object)
   """
   @derive {Inspect, except: [:raw_data]}
-  defstruct coordinates: nil, created_at: nil, current_user_retweet: nil,
-    entities: nil, extended_entities: nil, favorite_count: nil, favorited: nil,
-    filter_level: nil, id_str: nil, id: nil, in_reply_to_screen_name: nil,
-    in_reply_to_status_id_str: nil, in_reply_to_status_id: nil, in_reply_to_user_id_str: nil,
-    in_reply_to_user_id: nil, is_quote_status: nil, lang: nil, matching_rules: nil,
-    place: nil, possibly_sensitive: nil, quote_count: nil, quoted_status_id_str: nil,
-    quoted_status_id: nil, quoted_status: nil, raw_data: nil, reply_count: nil,
-    retweet_count: nil, retweeted_status: nil, retweeted: nil, scopes: nil, source: nil,
-    text: nil, full_text: nil, truncated: nil, user: nil, withheld_copyright: nil,
-    withheld_in_countries: nil, withheld_scope: nil
+  defstruct coordinates: nil,
+            created_at: nil,
+            current_user_retweet: nil,
+            entities: nil,
+            extended_entities: nil,
+            favorite_count: nil,
+            favorited: nil,
+            filter_level: nil,
+            id_str: nil,
+            id: nil,
+            in_reply_to_screen_name: nil,
+            in_reply_to_status_id_str: nil,
+            in_reply_to_status_id: nil,
+            in_reply_to_user_id_str: nil,
+            in_reply_to_user_id: nil,
+            is_quote_status: nil,
+            lang: nil,
+            matching_rules: nil,
+            place: nil,
+            possibly_sensitive: nil,
+            quote_count: nil,
+            quoted_status_id_str: nil,
+            quoted_status_id: nil,
+            quoted_status: nil,
+            raw_data: nil,
+            reply_count: nil,
+            retweet_count: nil,
+            retweeted_status: nil,
+            retweeted: nil,
+            scopes: nil,
+            source: nil,
+            text: nil,
+            full_text: nil,
+            truncated: nil,
+            user: nil,
+            withheld_copyright: nil,
+            withheld_in_countries: nil,
+            withheld_scope: nil
 
   @type t :: %__MODULE__{
-    coordinates: ExTwitter.Model.Coordinates.t() | nil,
-    created_at: String.t(),
-    current_user_retweet: %{id: pos_integer, id_str: String.t()} | nil,
-    entities: ExTwitter.Model.Entities.t(),
-    extended_entities: ExTwitter.Model.ExtendedEntities.t() | nil,
-    favorite_count: non_neg_integer | nil,
-    favorited: boolean | nil,
-    filter_level: String.t(),
-    id_str: String.t(),
-    id: pos_integer,
-    in_reply_to_screen_name: String.t() | nil,
-    in_reply_to_status_id_str: String.t() | nil,
-    in_reply_to_status_id: pos_integer | nil,
-    in_reply_to_user_id_str: String.t() | nil,
-    in_reply_to_user_id: pos_integer | nil,
-    is_quote_status: boolean,
-    lang: String.t() | nil,
-    matching_rules: [ExTwitter.Model.Rule.t()],
-    place: ExTwitter.Model.Place.t() | nil,
-    possibly_sensitive: boolean | nil,
-    quote_count: non_neg_integer | nil,
-    quoted_status_id_str: String.t() | nil,
-    quoted_status_id: pos_integer | nil,
-    quoted_status: ExTwitter.Model.Tweet.t() | nil,
-    raw_data: map,
-    reply_count: non_neg_integer | nil,
-    retweet_count: non_neg_integer,
-    retweeted_status: ExTwitter.Model.Tweet.t() | nil,
-    retweeted: boolean,
-    scopes: map | nil,
-    source: String.t(),
-    text: String.t(),
-    full_text: String.t(),
-    truncated: boolean,
-    user: ExTwitter.Model.User.t(),
-    withheld_copyright: boolean | nil,
-    withheld_in_countries: [String.t()] | nil,
-    withheld_scope: String.t() | nil
-  }
+          coordinates: ExTwitter.Model.Coordinates.t() | nil,
+          created_at: String.t(),
+          current_user_retweet: %{id: pos_integer, id_str: String.t()} | nil,
+          entities: ExTwitter.Model.Entities.t(),
+          extended_entities: ExTwitter.Model.ExtendedEntities.t() | nil,
+          favorite_count: non_neg_integer | nil,
+          favorited: boolean | nil,
+          filter_level: String.t(),
+          id_str: String.t(),
+          id: pos_integer,
+          in_reply_to_screen_name: String.t() | nil,
+          in_reply_to_status_id_str: String.t() | nil,
+          in_reply_to_status_id: pos_integer | nil,
+          in_reply_to_user_id_str: String.t() | nil,
+          in_reply_to_user_id: pos_integer | nil,
+          is_quote_status: boolean,
+          lang: String.t() | nil,
+          matching_rules: [ExTwitter.Model.Rule.t()],
+          place: ExTwitter.Model.Place.t() | nil,
+          possibly_sensitive: boolean | nil,
+          quote_count: non_neg_integer | nil,
+          quoted_status_id_str: String.t() | nil,
+          quoted_status_id: pos_integer | nil,
+          quoted_status: ExTwitter.Model.Tweet.t() | nil,
+          raw_data: map,
+          reply_count: non_neg_integer | nil,
+          retweet_count: non_neg_integer,
+          retweeted_status: ExTwitter.Model.Tweet.t() | nil,
+          retweeted: boolean,
+          scopes: map | nil,
+          source: String.t(),
+          text: String.t(),
+          full_text: String.t(),
+          truncated: boolean,
+          user: ExTwitter.Model.User.t(),
+          withheld_copyright: boolean | nil,
+          withheld_in_countries: [String.t()] | nil,
+          withheld_scope: String.t() | nil
+        }
 end
 
 defmodule ExTwitter.Model.Upload do
   @derive {Inspect, except: [:raw_data]}
-  defstruct expires_after_secs: nil, media_id: nil, media_id_string: nil, size: nil,
-    raw_data: nil
+  defstruct expires_after_secs: nil, media_id: nil, media_id_string: nil, size: nil, raw_data: nil
 
   @type t :: %__MODULE__{
-    expires_after_secs: non_neg_integer,
-    media_id: pos_integer,
-    media_id_string: String.t(),
-    size: pos_integer | nil,
-    raw_data: map
-  }
+          expires_after_secs: non_neg_integer,
+          media_id: pos_integer,
+          media_id_string: String.t(),
+          size: pos_integer | nil,
+          raw_data: map
+        }
 end
 
 defmodule ExTwitter.Model.User do
@@ -83,38 +110,55 @@ defmodule ExTwitter.Model.User do
   [User object](https://developer.twitter.com/en/docs/tweets/data-dictionary/overview/user-object)
   """
   @derive {Inspect, except: [:raw_data]}
-  defstruct created_at: nil, default_profile_image: nil, default_profile: nil,
-    derived: nil, description: nil, favourites_count: nil, followers_count: nil,
-    friends_count: nil, id_str: nil, id: nil, listed_count: nil, location: nil,
-    name: nil, profile_banner_url: nil, profile_image_url_https: nil, protected: nil,
-    raw_data: nil, screen_name: nil, statuses_count: nil, url: nil, verified: nil,
-    withheld_in_countries: nil, withheld_scope: nil
+  defstruct created_at: nil,
+            default_profile_image: nil,
+            default_profile: nil,
+            derived: nil,
+            description: nil,
+            favourites_count: nil,
+            followers_count: nil,
+            friends_count: nil,
+            id_str: nil,
+            id: nil,
+            listed_count: nil,
+            location: nil,
+            name: nil,
+            profile_banner_url: nil,
+            profile_image_url_https: nil,
+            protected: nil,
+            raw_data: nil,
+            screen_name: nil,
+            statuses_count: nil,
+            url: nil,
+            verified: nil,
+            withheld_in_countries: nil,
+            withheld_scope: nil
 
   @type t :: %__MODULE__{
-    created_at: String.t(),
-    default_profile_image: boolean,
-    default_profile: boolean,
-    derived: [ExTwitter.Model.ProfileGeo.t()] | nil,
-    description: String.t() | nil,
-    favourites_count: non_neg_integer,
-    followers_count: non_neg_integer,
-    friends_count: non_neg_integer,
-    id_str: String.t(),
-    id: pos_integer,
-    listed_count: non_neg_integer,
-    location: String.t() | nil,
-    name: String.t(),
-    profile_banner_url: String.t(),
-    profile_image_url_https: String.t(),
-    protected: boolean,
-    raw_data: map,
-    screen_name: String.t(),
-    statuses_count: non_neg_integer,
-    url: String.t() | nil,
-    verified: boolean,
-    withheld_in_countries: [String.t()],
-    withheld_scope: String.t()
-  }
+          created_at: String.t(),
+          default_profile_image: boolean,
+          default_profile: boolean,
+          derived: [ExTwitter.Model.ProfileGeo.t()] | nil,
+          description: String.t() | nil,
+          favourites_count: non_neg_integer,
+          followers_count: non_neg_integer,
+          friends_count: non_neg_integer,
+          id_str: String.t(),
+          id: pos_integer,
+          listed_count: non_neg_integer,
+          location: String.t() | nil,
+          name: String.t(),
+          profile_banner_url: String.t(),
+          profile_image_url_https: String.t(),
+          protected: boolean,
+          raw_data: map,
+          screen_name: String.t(),
+          statuses_count: non_neg_integer,
+          url: String.t() | nil,
+          verified: boolean,
+          withheld_in_countries: [String.t()],
+          withheld_scope: String.t()
+        }
 end
 
 defmodule ExTwitter.Model.ProfileBanner do
@@ -133,9 +177,17 @@ end
 
 defmodule ExTwitter.Model.DirectMessage do
   @derive {Inspect, except: [:raw_data]}
-  defstruct created_at: nil, entities: nil, id: nil, id_str: nil,
-    recipient: nil, recipient_id: nil, recipient_screen_name: nil,
-    sender: nil, sender_id: nil, sender_screen_name: nil, text: nil
+  defstruct created_at: nil,
+            entities: nil,
+            id: nil,
+            id_str: nil,
+            recipient: nil,
+            recipient_id: nil,
+            recipient_screen_name: nil,
+            sender: nil,
+            sender_id: nil,
+            sender_screen_name: nil,
+            text: nil
 
   @type t :: %__MODULE__{}
 end
@@ -149,18 +201,23 @@ defmodule ExTwitter.Model.Entities do
   [Entities object[(https://developer.twitter.com/en/docs/tweets/data-dictionary/overview/entities-object)
   """
   @derive {Inspect, except: [:raw_data]}
-  defstruct hashtags: nil, media: nil, symbols: nil, urls: nil, user_mentions: nil,
-    polls: nil, raw_data: nil
+  defstruct hashtags: nil,
+            media: nil,
+            symbols: nil,
+            urls: nil,
+            user_mentions: nil,
+            polls: nil,
+            raw_data: nil
 
   @type t :: %__MODULE__{
-    hashtags: [ExTwitter.Model.Hashtag],
-    media: [ExTwitter.Model.Media],
-    symbols: [ExTwitter.Model.Symbol],
-    urls: [ExTwitter.Model.URL],
-    user_mentions: [ExTwitter.Model.UserMention],
-    polls: [ExTwitter.Model.Poll],
-    raw_data: map
-  }
+          hashtags: [ExTwitter.Model.Hashtag],
+          media: [ExTwitter.Model.Media],
+          symbols: [ExTwitter.Model.Symbol],
+          urls: [ExTwitter.Model.URL],
+          user_mentions: [ExTwitter.Model.UserMention],
+          polls: [ExTwitter.Model.Poll],
+          raw_data: map
+        }
 end
 
 defmodule ExTwitter.Model.ExtendedEntities do
@@ -172,18 +229,23 @@ defmodule ExTwitter.Model.ExtendedEntities do
   [Extended Entities object](https://developer.twitter.com/en/docs/tweets/data-dictionary/overview/extended-entities-object)
   """
   @derive {Inspect, except: [:raw_data]}
-  defstruct hashtags: nil, media: nil, symbols: nil, urls: nil, user_mentions: nil,
-    polls: nil, raw_data: nil
+  defstruct hashtags: nil,
+            media: nil,
+            symbols: nil,
+            urls: nil,
+            user_mentions: nil,
+            polls: nil,
+            raw_data: nil
 
   @type t :: %__MODULE__{
-    hashtags: [ExTwitter.Model.Hashtag],
-    media: [ExTwitter.Model.Media],
-    symbols: [ExTwitter.Model.Symbol],
-    urls: [ExTwitter.Model.URL],
-    user_mentions: [ExTwitter.Model.UserMention],
-    polls: [ExTwitter.Model.Poll],
-    raw_data: map
-  }
+          hashtags: [ExTwitter.Model.Hashtag],
+          media: [ExTwitter.Model.Media],
+          symbols: [ExTwitter.Model.Symbol],
+          urls: [ExTwitter.Model.URL],
+          user_mentions: [ExTwitter.Model.UserMention],
+          polls: [ExTwitter.Model.Poll],
+          raw_data: map
+        }
 end
 
 defmodule ExTwitter.Model.Hashtag do
@@ -198,10 +260,10 @@ defmodule ExTwitter.Model.Hashtag do
   defstruct indices: nil, text: nil, raw_data: nil
 
   @type t :: %__MODULE__{
-    indices: [non_neg_integer],
-    text: String.t(),
-    raw_data: map
-  }
+          indices: [non_neg_integer],
+          text: String.t(),
+          raw_data: map
+        }
 end
 
 defmodule ExTwitter.Model.Media do
@@ -212,25 +274,35 @@ defmodule ExTwitter.Model.Media do
   [Media object](https://developer.twitter.com/en/docs/tweets/data-dictionary/overview/entities-object#media)
   """
   @derive {Inspect, except: [:raw_data]}
-  defstruct display_url: nil, expanded_url: nil, id: nil, id_str: nil, indices: nil,
-    media_url: nil, media_url_https: nil, sizes: nil, source_status_id: nil,
-    source_status_id_str: nil, type: nil, url: nil, raw_data: nil
+  defstruct display_url: nil,
+            expanded_url: nil,
+            id: nil,
+            id_str: nil,
+            indices: nil,
+            media_url: nil,
+            media_url_https: nil,
+            sizes: nil,
+            source_status_id: nil,
+            source_status_id_str: nil,
+            type: nil,
+            url: nil,
+            raw_data: nil
 
   @type t :: %__MODULE__{
-    display_url: String.t(),
-    expanded_url: String.t(),
-    id: pos_integer,
-    id_str: String.t(),
-    indices: [non_neg_integer],
-    media_url: String.t(),
-    media_url_https: String.t(),
-    sizes: %{required(String.t()) => ExTwitter.Model.Size.t()},
-    source_status_id: pos_integer | nil,
-    source_status_id_str: String.t() | nil,
-    type: String.t(),
-    url: String.t(),
-    raw_data: map
-  }
+          display_url: String.t(),
+          expanded_url: String.t(),
+          id: pos_integer,
+          id_str: String.t(),
+          indices: [non_neg_integer],
+          media_url: String.t(),
+          media_url_https: String.t(),
+          sizes: %{required(String.t()) => ExTwitter.Model.Size.t()},
+          source_status_id: pos_integer | nil,
+          source_status_id_str: String.t() | nil,
+          type: String.t(),
+          url: String.t(),
+          raw_data: map
+        }
 end
 
 defmodule ExTwitter.Model.Size do
@@ -245,11 +317,11 @@ defmodule ExTwitter.Model.Size do
   defstruct h: nil, w: nil, resize: nil, raw_data: nil
 
   @type t :: %__MODULE__{
-    h: pos_integer,
-    w: pos_integer,
-    resize: String.t(),
-    raw_data: map
-  }
+          h: pos_integer,
+          w: pos_integer,
+          resize: String.t(),
+          raw_data: map
+        }
 end
 
 defmodule ExTwitter.Model.Symbol do
@@ -264,12 +336,11 @@ defmodule ExTwitter.Model.Symbol do
   defstruct indices: nil, text: nil, raw_data: nil
 
   @type t :: %__MODULE__{
-    indices: [non_neg_integer],
-    text: String.t(),
-    raw_data: map
-  }
+          indices: [non_neg_integer],
+          text: String.t(),
+          raw_data: map
+        }
 end
-
 
 defmodule ExTwitter.Model.URL do
   @moduledoc """
@@ -280,16 +351,21 @@ defmodule ExTwitter.Model.URL do
   [URL object](https://developer.twitter.com/en/docs/tweets/data-dictionary/overview/entities-object#urls)
   """
   @derive {Inspect, except: [:raw_data]}
-  defstruct display_url: nil, expanded_url: nil, indices: nil, url: nil, unwound: nil, raw_data: nil
+  defstruct display_url: nil,
+            expanded_url: nil,
+            indices: nil,
+            url: nil,
+            unwound: nil,
+            raw_data: nil
 
   @type t :: %__MODULE__{
-    display_url: String.t(),
-    expanded_url: String.t(),
-    indices: [non_neg_integer],
-    url: String.t(),
-    unwound: map | nil,
-    raw_data: map
-  }
+          display_url: String.t(),
+          expanded_url: String.t(),
+          indices: [non_neg_integer],
+          url: String.t(),
+          unwound: map | nil,
+          raw_data: map
+        }
 end
 
 defmodule ExTwitter.Model.UserMention do
@@ -304,14 +380,13 @@ defmodule ExTwitter.Model.UserMention do
   defstruct id: nil, id_str: nil, indices: nil, name: nil, screen_name: nil, raw_data: nil
 
   @type t :: %__MODULE__{
-    id: pos_integer,
-    id_str: String.t(),
-    indices: [non_neg_integer],
-    name: String.t(),
-    screen_name: String.t()
-  }
+          id: pos_integer,
+          id_str: String.t(),
+          indices: [non_neg_integer],
+          name: String.t(),
+          screen_name: String.t()
+        }
 end
-
 
 defmodule ExTwitter.Model.Poll do
   @moduledoc """
@@ -325,11 +400,11 @@ defmodule ExTwitter.Model.Poll do
   defstruct options: nil, end_datetime: nil, duration_minutes: nil, raw_data: nil
 
   @type t :: %__MODULE__{
-    options: [map],
-    end_datetime: String.t(),
-    duration_minutes: pos_integer,
-    raw_data: map
-  }
+          options: [map],
+          end_datetime: String.t(),
+          duration_minutes: pos_integer,
+          raw_data: map
+        }
 end
 
 defmodule ExTwitter.Model.Rule do
@@ -355,18 +430,24 @@ defmodule ExTwitter.Model.ProfileGeo do
   [Profile Geo](https://developer.twitter.com/en/docs/tweets/enrichments/overview/profile-geo)
   """
   @derive {Inspect, except: [:raw_data]}
-  defstruct country: nil, country_code: nil, locality: nil, region: nil, sub_region: nil,
-    full_name: nil, geo: nil, raw_data: nil
+  defstruct country: nil,
+            country_code: nil,
+            locality: nil,
+            region: nil,
+            sub_region: nil,
+            full_name: nil,
+            geo: nil,
+            raw_data: nil
 
   @type t :: %__MODULE__{
-    country: String.t(),
-    country_code: String.t(),
-    locality: String.t(),
-    region: String.t(),
-    sub_region: String.t(),
-    full_name: String.t(),
-    geo: ExTwitter.Model.Geo.t()
-  }
+          country: String.t(),
+          country_code: String.t(),
+          locality: String.t(),
+          region: String.t(),
+          sub_region: String.t(),
+          full_name: String.t(),
+          geo: ExTwitter.Model.Geo.t()
+        }
 end
 
 defmodule ExTwitter.Model.Trend do
@@ -378,16 +459,21 @@ defmodule ExTwitter.Model.Trend do
   https://developer.twitter.com/en/docs/trends/trends-for-location/api-reference/get-trends-place
   """
   @derive {Inspect, except: [:raw_data]}
-  defstruct name: nil, promoted_content: nil, query: nil, raw_data: nil, tweet_volume: nil, url: nil
+  defstruct name: nil,
+            promoted_content: nil,
+            query: nil,
+            raw_data: nil,
+            tweet_volume: nil,
+            url: nil
 
   @type t :: %__MODULE__{
-    name: String.t(),
-    promoted_content: String.t() | nil,
-    query: String.t(),
-    raw_data: map,
-    tweet_volume: pos_integer | nil,
-    url: String.t()
-  }
+          name: String.t(),
+          promoted_content: String.t() | nil,
+          query: String.t(),
+          raw_data: map,
+          tweet_volume: pos_integer | nil,
+          url: String.t()
+        }
 end
 
 defmodule ExTwitter.Model.List do
@@ -399,26 +485,37 @@ defmodule ExTwitter.Model.List do
   https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-show
   """
   @derive {Inspect, except: [:raw_data]}
-  defstruct created_at: nil, description: nil, following: nil, full_name: nil,
-    id_str: nil, id: nil, member_count: nil, mode: nil, name: nil, raw_data: nil,
-    slug: nil, subscriber_count: nil, uri: nil, user: nil
+  defstruct created_at: nil,
+            description: nil,
+            following: nil,
+            full_name: nil,
+            id_str: nil,
+            id: nil,
+            member_count: nil,
+            mode: nil,
+            name: nil,
+            raw_data: nil,
+            slug: nil,
+            subscriber_count: nil,
+            uri: nil,
+            user: nil
 
   @type t :: %__MODULE__{
-    created_at: String.t(),
-    description: String.t(),
-    following: boolean,
-    full_name: String.t(),
-    id_str: String.t(),
-    id: pos_integer,
-    member_count: non_neg_integer,
-    mode: String.t(),
-    name: String.t(),
-    raw_data: map,
-    slug: String.t(),
-    subscriber_count: non_neg_integer,
-    uri: String.t(),
-    user: ExTwitter.Model.User.t()
-  }
+          created_at: String.t(),
+          description: String.t(),
+          following: boolean,
+          full_name: String.t(),
+          id_str: String.t(),
+          id: pos_integer,
+          member_count: non_neg_integer,
+          mode: String.t(),
+          name: String.t(),
+          raw_data: map,
+          slug: String.t(),
+          subscriber_count: non_neg_integer,
+          uri: String.t(),
+          user: ExTwitter.Model.User.t()
+        }
 end
 
 defmodule ExTwitter.Model.Place do
@@ -430,23 +527,31 @@ defmodule ExTwitter.Model.Place do
   [Place object](https://developer.twitter.com/en/docs/tweets/data-dictionary/overview/geo-objects#place)
   """
   @derive {Inspect, except: [:raw_data]}
-  defstruct id: nil, url: nil, place_type: nil, name: nil, full_name: nil,
-    country_code: nil, country: nil, contained_within: nil,
-    bounding_box: nil, attributes: nil, raw_data: nil
+  defstruct id: nil,
+            url: nil,
+            place_type: nil,
+            name: nil,
+            full_name: nil,
+            country_code: nil,
+            country: nil,
+            contained_within: nil,
+            bounding_box: nil,
+            attributes: nil,
+            raw_data: nil
 
   @type t :: %__MODULE__{
-    id: String.t(),
-    url: String.t(),
-    place_type: String.t(),
-    name: String.t(),
-    full_name: String.t(),
-    country_code: String.t(),
-    country: String.t(),
-    contained_within: [ExTwitter.Model.Place.t()],
-    bounding_box: ExTwitter.Model.BoundingBox.t(),
-    attributes: nil,
-    raw_data: map
-  }
+          id: String.t(),
+          url: String.t(),
+          place_type: String.t(),
+          name: String.t(),
+          full_name: String.t(),
+          country_code: String.t(),
+          country: String.t(),
+          contained_within: [ExTwitter.Model.Place.t()],
+          bounding_box: ExTwitter.Model.BoundingBox.t(),
+          attributes: nil,
+          raw_data: map
+        }
 end
 
 defmodule ExTwitter.Model.BoundingBox do
@@ -461,10 +566,10 @@ defmodule ExTwitter.Model.BoundingBox do
   defstruct coordinates: nil, type: nil, raw_data: nil
 
   @type t :: %__MODULE__{
-    coordinates: [[[float]]],
-    type: String.t(),
-    raw_data: map
-  }
+          coordinates: [[[float]]],
+          type: String.t(),
+          raw_data: map
+        }
 end
 
 defmodule ExTwitter.Model.Coordinates do
@@ -479,10 +584,10 @@ defmodule ExTwitter.Model.Coordinates do
   defstruct coordinates: nil, type: nil, raw_data: nil
 
   @type t :: %__MODULE__{
-    coordinates: [float],
-    type: String.t(),
-    raw_data: map
-  }
+          coordinates: [float],
+          type: String.t(),
+          raw_data: map
+        }
 end
 
 defmodule ExTwitter.Model.Geo do
@@ -497,10 +602,10 @@ defmodule ExTwitter.Model.Geo do
   defstruct coordinates: nil, type: nil, raw_data: nil
 
   @type t :: %__MODULE__{
-    coordinates: [float],
-    type: String.t(),
-    raw_data: map
-  }
+          coordinates: [float],
+          type: String.t(),
+          raw_data: map
+        }
 end
 
 defmodule ExTwitter.Model.DeletedTweet do
@@ -540,10 +645,10 @@ defmodule ExTwitter.Model.StallWarning do
   defstruct code: nil, message: nil, percent_full: nil
 
   @type t :: %__MODULE__{
-    code: String.t(),
-    message: String.t(),
-    percent_full: non_neg_integer
-  }
+          code: String.t(),
+          message: String.t(),
+          percent_full: non_neg_integer
+        }
 end
 
 defmodule ExTwitter.Model.Cursor do
@@ -558,11 +663,11 @@ defmodule ExTwitter.Model.Cursor do
   defstruct items: nil, next_cursor: nil, previous_cursor: nil, raw_data: nil
 
   @type t :: %__MODULE__{
-    items: [ExTwitter.Model.User.t()] | [pos_integer],
-    next_cursor: integer,
-    previous_cursor: integer,
-    raw_data: map
-  }
+          items: [ExTwitter.Model.User.t()] | [pos_integer],
+          next_cursor: integer,
+          previous_cursor: integer,
+          raw_data: map
+        }
 end
 
 defmodule ExTwitter.Model.RequestToken do
@@ -574,15 +679,17 @@ defmodule ExTwitter.Model.RequestToken do
   [POST oauth/request_token](https://developer.twitter.com/en/docs/basics/authentication/api-reference/request_token)
   """
   @derive {Inspect, except: [:raw_data]}
-  defstruct oauth_token: nil, oauth_token_secret: nil, oauth_callback_confirmed: nil,
-    raw_data: nil
+  defstruct oauth_token: nil,
+            oauth_token_secret: nil,
+            oauth_callback_confirmed: nil,
+            raw_data: nil
 
   @type t :: %__MODULE__{
-    oauth_token: String.t(),
-    oauth_token_secret: String.t(),
-    oauth_callback_confirmed: boolean,
-    raw_data: map
-  }
+          oauth_token: String.t(),
+          oauth_token_secret: String.t(),
+          oauth_callback_confirmed: boolean,
+          raw_data: map
+        }
 end
 
 defmodule ExTwitter.Model.AccessToken do
@@ -594,16 +701,19 @@ defmodule ExTwitter.Model.AccessToken do
   [POST oauth/access_token](https://developer.twitter.com/en/docs/basics/authentication/api-reference/access_token)
   """
   @derive {Inspect, except: [:raw_data]}
-  defstruct oauth_token: nil, oauth_token_secret: nil, user_id: nil, screen_name: nil,
-    raw_data: nil
+  defstruct oauth_token: nil,
+            oauth_token_secret: nil,
+            user_id: nil,
+            screen_name: nil,
+            raw_data: nil
 
   @type t :: %__MODULE__{
-    oauth_token: String.t(),
-    oauth_token_secret: String.t(),
-    user_id: String.t(),
-    screen_name: String.t(),
-    raw_data: map
-  }
+          oauth_token: String.t(),
+          oauth_token_secret: String.t(),
+          user_id: String.t(),
+          screen_name: String.t(),
+          raw_data: map
+        }
 end
 
 defmodule ExTwitter.Model.SearchResponse do
@@ -628,15 +738,14 @@ defmodule ExTwitter.Model.Relationship do
   [GET friendships/lookup](https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friendships-lookup)
   """
   @derive {Inspect, except: [:raw_data]}
-  defstruct name: nil, screen_name: nil, id: nil, id_str: nil, connections: nil,
-    raw_data: nil
+  defstruct name: nil, screen_name: nil, id: nil, id_str: nil, connections: nil, raw_data: nil
 
   @type t :: %__MODULE__{
-    name: String.t(),
-    screen_name: String.t(),
-    id: pos_integer,
-    id_str: String.t(),
-    connections: [String.t()],
-    raw_data: map
-  }
+          name: String.t(),
+          screen_name: String.t(),
+          id: pos_integer,
+          id_str: String.t(),
+          connections: [String.t()],
+          raw_data: map
+        }
 end


### PR DESCRIPTION
1. Run formatter
2. Since Elixir 1.14 if the `:except` list of `@derive` contains missing fields it raises a compile-time error. `ExTwitter.Model.DirectMessage` does not have a `:raw_data` field, so it should not be present in the `:except` field